### PR TITLE
Add an example for installing java 8

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,6 +34,14 @@ class { 'java':
 }
 ~~~
 
+Example installing the latest patch version of java 8 on Centos 
+
+~~~
+class { 'java' :
+  package => 'java-1.8.0-openjdk-devel',
+}
+~~~
+
 The defined type `java::oracle` installs one or more versions of Oracle Java SE. `java::oracle` depends on [puppet/archive](https://github.com/voxpupuli/puppet-archive).  By using `java::oracle` you agree to Oracle's licensing terms for Java SE.
 
 ~~~


### PR DESCRIPTION
Prior to this commit, the documentation was lacking an example of how to install a specific version of java.  Which led users to believe that they should use the version parameter.  

After this commit, we have an example showing the correct way to install a different major verison of java is to use the package parameter.
